### PR TITLE
feat: context-aware Nora help drawer + Min side in wp-admin [1.5.0]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.5.0]
+
+### Added
+
+- Min side integration in the Nora drawer. When the minside-SSO bridge plugin is
+  present and configured, the drawer shows a «Min side»-section in its top bar
+  (Åpne Min side + Trafikk & drift / Fakturaer / Support-saker + Kontakt oss).
+  Clicking a link postMessages this parent page, which opens the matching
+  minside-SSO launch URL (token minted server-side; origin-validated against the
+  hjelp.nettsmed.no iframe). This replaces the separate floating «Åpne Min side»
+  launcher so wp-admin has a single widget — Nora.
+
 ## [1.4.0]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.4.0]
+
+### Added
+
+- Nora — context-aware AI help drawer in wp-admin. Enqueues the shared Nettsmed
+  chat widget from hjelp.nettsmed.no across admin pages, passing the current
+  screen id and detected stack (WooCommerce / Elementor / Gutenberg / WordPress)
+  so the drawer surfaces screen-aware suggestions and weights its answers. Help
+  content is public, so no auth/token crosses the iframe. New `inc/ai-help-drawer.php`;
+  help center base overridable via the `NETTSMED_HELP_BASE` constant.
+
 ## [1.3.1]
 
 ### Fixed

--- a/inc/ai-help-drawer.php
+++ b/inc/ai-help-drawer.php
@@ -110,13 +110,19 @@ function nettsmed_help_enqueue_drawer() {
 	// Min side section; we map it to the minside-SSO launch URL (minted server-
 	// side, nonce included) and open it. Origin-validated against the iframe.
 	if ( $minside ) {
+		// launch_url() is esc_html'd (built for an href, so its ampersands are
+		// &amp;). These URLs go into JS window.open() — a non-HTML context where
+		// &amp; would NOT be decoded, breaking the _wpnonce param — so decode them.
+		$launch = static function ( $next ) use ( $ns ) {
+			return html_entity_decode( (string) call_user_func( $ns . 'launch_url', $next ), ENT_QUOTES );
+		};
 		$cfg = array(
 			'origin' => untrailingslashit( NETTSMED_HELP_BASE ),
 			'urls'   => array(
-				''         => call_user_func( $ns . 'launch_url', '' ),
-				'/drift'   => call_user_func( $ns . 'launch_url', '/drift' ),
-				'/faktura' => call_user_func( $ns . 'launch_url', '/faktura' ),
-				'/support' => call_user_func( $ns . 'launch_url', '/support' ),
+				''         => $launch( '' ),
+				'/drift'   => $launch( '/drift' ),
+				'/faktura' => $launch( '/faktura' ),
+				'/support' => $launch( '/support' ),
 			),
 		);
 		$inline = 'window.__noraMinside=' . wp_json_encode( $cfg ) . ';'

--- a/inc/ai-help-drawer.php
+++ b/inc/ai-help-drawer.php
@@ -64,6 +64,18 @@ function nettsmed_help_enqueue_drawer() {
 	$screen_id = $screen ? (string) $screen->id : '';
 	$stack     = nettsmed_help_detect_stack();
 
+	// Min side integration — only when the minside-SSO bridge plugin is present
+	// and configured on this site. The drawer then shows a Min side section in
+	// its top bar; clicking a link asks this parent page (via postMessage) to
+	// launch minside over SSO, so no token crosses the iframe.
+	$ns      = 'Nettsmed\\MinsideSSO\\';
+	$minside = function_exists( $ns . 'launch_url' )
+		&& function_exists( $ns . 'is_configured' )
+		&& call_user_func( $ns . 'is_configured' );
+	$email   = ( $minside && function_exists( $ns . 'support_email' ) )
+		? (string) call_user_func( $ns . 'support_email' )
+		: '';
+
 	$src = trailingslashit( NETTSMED_HELP_BASE ) . 'widget.js';
 
 	// Version null → no ?ver= query; the widget loader pins itself.
@@ -72,7 +84,7 @@ function nettsmed_help_enqueue_drawer() {
 	// The widget.js loader is data-* driven; inject the attributes onto its tag.
 	add_filter(
 		'script_loader_tag',
-		function ( $tag, $handle ) use ( $screen_id, $stack ) {
+		function ( $tag, $handle ) use ( $screen_id, $stack, $minside, $email ) {
 			if ( 'nettsmed-help-widget' !== $handle ) {
 				return $tag;
 			}
@@ -85,10 +97,34 @@ function nettsmed_help_enqueue_drawer() {
 				esc_attr( $screen_id ),
 				esc_attr( $stack )
 			);
+			if ( $minside ) {
+				$attrs .= sprintf( ' data-minside="1" data-email="%s"', esc_attr( $email ) );
+			}
 			return str_replace( ' src=', $attrs . ' src=', $tag );
 		},
 		10,
 		2
 	);
+
+	// Parent-side bridge: the drawer (hjelp.nettsmed.no iframe) asks us to open a
+	// Min side section; we map it to the minside-SSO launch URL (minted server-
+	// side, nonce included) and open it. Origin-validated against the iframe.
+	if ( $minside ) {
+		$cfg = array(
+			'origin' => untrailingslashit( NETTSMED_HELP_BASE ),
+			'urls'   => array(
+				''         => call_user_func( $ns . 'launch_url', '' ),
+				'/drift'   => call_user_func( $ns . 'launch_url', '/drift' ),
+				'/faktura' => call_user_func( $ns . 'launch_url', '/faktura' ),
+				'/support' => call_user_func( $ns . 'launch_url', '/support' ),
+			),
+		);
+		$inline = 'window.__noraMinside=' . wp_json_encode( $cfg ) . ';'
+			. '(function(){var C=window.__noraMinside;if(!C)return;'
+			. 'window.addEventListener("message",function(e){if(e.origin!==C.origin)return;'
+			. 'var d=e.data;if(!d||d.type!=="nettsmed-open-minside")return;'
+			. 'var u=C.urls[d.next||""];if(u){window.open(u,"_blank","noopener");}});})();';
+		wp_add_inline_script( 'nettsmed-help-widget', $inline, 'after' );
+	}
 }
 add_action( 'admin_enqueue_scripts', 'nettsmed_help_enqueue_drawer' );

--- a/inc/ai-help-drawer.php
+++ b/inc/ai-help-drawer.php
@@ -1,0 +1,94 @@
+<?php
+/**
+ * Nora — context-aware AI help drawer in wp-admin.
+ *
+ * Enqueues the shared Nettsmed chat widget (hjelp.nettsmed.no) across wp-admin,
+ * passing the current admin screen id and the site's detected stack so the
+ * drawer surfaces screen-aware suggestions and weights its answers. The drawer
+ * serves public help content, so no auth/token crosses the iframe — the plugin
+ * only reports context.
+ *
+ * @package Nettsmed\Support
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+if ( ! defined( 'NETTSMED_HELP_BASE' ) ) {
+	// Overridable per-site via wp-config (e.g. a staging help center).
+	define( 'NETTSMED_HELP_BASE', 'https://hjelp.nettsmed.no' );
+}
+
+/**
+ * Detect the active stack as a comma-separated list matching hjelp.nettsmed.no's
+ * HelpStack vocabulary: wordpress | elementor | gutenberg | woocommerce | generell.
+ *
+ * @return string CSV of detected stacks (always includes 'wordpress').
+ */
+function nettsmed_help_detect_stack() {
+	if ( ! function_exists( 'is_plugin_active' ) ) {
+		require_once ABSPATH . 'wp-admin/includes/plugin.php';
+	}
+
+	$stack = array( 'wordpress' );
+
+	if ( is_plugin_active( 'woocommerce/woocommerce.php' ) ) {
+		$stack[] = 'woocommerce';
+	}
+
+	if ( is_plugin_active( 'elementor/elementor.php' ) || is_plugin_active( 'elementor-pro/elementor-pro.php' ) ) {
+		$stack[] = 'elementor';
+	}
+
+	// Block editor (Gutenberg) — only meaningful on an editor screen.
+	$screen = function_exists( 'get_current_screen' ) ? get_current_screen() : null;
+	if ( $screen && method_exists( $screen, 'is_block_editor' ) && $screen->is_block_editor() ) {
+		$stack[] = 'gutenberg';
+	}
+
+	return implode( ',', array_unique( $stack ) );
+}
+
+/**
+ * Enqueue the help widget on admin pages, tagged with the current screen + stack.
+ *
+ * @return void
+ */
+function nettsmed_help_enqueue_drawer() {
+	if ( ! is_user_logged_in() ) {
+		return;
+	}
+
+	$screen    = function_exists( 'get_current_screen' ) ? get_current_screen() : null;
+	$screen_id = $screen ? (string) $screen->id : '';
+	$stack     = nettsmed_help_detect_stack();
+
+	$src = trailingslashit( NETTSMED_HELP_BASE ) . 'widget.js';
+
+	// Version null → no ?ver= query; the widget loader pins itself.
+	wp_enqueue_script( 'nettsmed-help-widget', $src, array(), null, true );
+
+	// The widget.js loader is data-* driven; inject the attributes onto its tag.
+	add_filter(
+		'script_loader_tag',
+		function ( $tag, $handle ) use ( $screen_id, $stack ) {
+			if ( 'nettsmed-help-widget' !== $handle ) {
+				return $tag;
+			}
+			$attrs = sprintf(
+				' data-base="%s" data-label="%s" data-aria="%s" data-title="%s" data-initial="N" data-screen="%s" data-stack="%s"',
+				esc_url( NETTSMED_HELP_BASE ),
+				esc_attr__( 'Hjelp', 'nettsmed-support' ),
+				esc_attr__( 'Åpne hjelp', 'nettsmed-support' ),
+				esc_attr__( 'Nettsmed hjelp', 'nettsmed-support' ),
+				esc_attr( $screen_id ),
+				esc_attr( $stack )
+			);
+			return str_replace( ' src=', $attrs . ' src=', $tag );
+		},
+		10,
+		2
+	);
+}
+add_action( 'admin_enqueue_scripts', 'nettsmed_help_enqueue_drawer' );

--- a/site-customization-by-fjellestad-design.php
+++ b/site-customization-by-fjellestad-design.php
@@ -3,7 +3,7 @@
 * Plugin Name: Site Customization by Nettsmed
 * Plugin URI: https://nettsmed.no
 * Description: Site customization plugin for Nettsmed customers.
- * Version: 1.3.1
+ * Version: 1.4.0
 * Author: Sindre Fjellestad
 * Author URI: https://github.com/Sinfjell
 */
@@ -25,6 +25,7 @@ require plugin_dir_path(__FILE__) . 'fjellestad-support-backend-widget.php';
 require plugin_dir_path(__FILE__) . 'remove-dashboard-widgets.php';
 require plugin_dir_path(__FILE__) . 'simpel-admin-role.php';
 require plugin_dir_path(__FILE__) . 'inc/admin-dashboard-settings.php';
+require plugin_dir_path(__FILE__) . 'inc/ai-help-drawer.php';
 
 register_activation_hook( __FILE__, 'create_simpel_admin_role' );
 

--- a/site-customization-by-fjellestad-design.php
+++ b/site-customization-by-fjellestad-design.php
@@ -3,7 +3,7 @@
 * Plugin Name: Site Customization by Nettsmed
 * Plugin URI: https://nettsmed.no
 * Description: Site customization plugin for Nettsmed customers.
- * Version: 1.4.0
+ * Version: 1.5.0
 * Author: Sindre Fjellestad
 * Author URI: https://github.com/Sinfjell
 */


### PR DESCRIPTION
## What
Adds **Nora**, a context-aware AI help drawer, to wp-admin. Enqueues the shared `@nettsmed/chat-widget` loader from `https://hjelp.nettsmed.no/widget.js` on admin pages, passing:
- `data-screen` = `get_current_screen()->id`
- `data-stack` = detected stack CSV (`wordpress` always; + `woocommerce` / `elementor` / `gutenberg` when active)

The hjelp `/embed` drawer uses these to show screen-aware suggested questions + relevant articles and to weight the answers.

## Notes
- Help content is **public**, so no auth/token crosses the iframe — the plugin only reports context.
- `NETTSMED_HELP_BASE` constant overrides the help-center origin (e.g. staging).
- `inc/ai-help-drawer.php`; wired into the main plugin file; bumped 1.3.1 to 1.4.0.
- `php -l` clean on both changed files.

## Release gating
Do NOT merge until validated on a single site (tverrkirkelig.no) — merging may trigger a Kernl fleet release to all client sites carrying this plugin.

Generated with Claude Code
