### PR TITLE
refactor(minside-sso): source JWT contract from generated single source of truth [1.8.1]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [1.8.1] - 2026-07-01
+
+### Changed
+
+- SSO mint now sources its JWT contract values (`iss`, `aud`, TTL) from a
+  vendored, auto-generated `inc/contracts.generated.php` instead of hardcoded
+  constants. This file is the shared single source of truth with minside's
+  verifier (`@nettsmed/contracts` in the `nettsmed-kundestotte` monorepo),
+  eliminating cross-repo drift. Emitted token values are byte-for-byte
+  identical to 1.8.0 — no runtime behavior change. Regenerate with
+  `pnpm gen:php` in the monorepo and re-copy the file on any contract change.
+
 ## [1.8.0] - 2026-06-30
 
 ### Removed

--- a/inc/contracts.generated.php
+++ b/inc/contracts.generated.php
@@ -1,0 +1,33 @@
+<?php
+// AUTO-GENERATED from @nettsmed/contracts — DO NOT EDIT.
+// Run `pnpm gen:php` in the minside-nettsmed monorepo and re-commit this file.
+if ( ! defined( 'NETTSMED_CONTRACTS_LOADED' ) ) {
+	define( 'NETTSMED_CONTRACTS_LOADED', true );
+	define( 'NETTSMED_SSO_ISS', 'nettsmed-support-plugin' );
+	define( 'NETTSMED_SSO_AUD', 'minside.nettsmed.no' );
+	define( 'NETTSMED_SSO_TTL', 90 );
+	define( 'NETTSMED_HELP_BASE', 'https://hjelp.nettsmed.no' );
+	define( 'NETTSMED_PM_EVENT', 'nettsmed-open-minside' );
+	$GLOBALS['NETTSMED_HELP_STACKS'] = [ 'elementor', 'gutenberg', 'woocommerce', 'wordpress', 'generell' ];
+	$GLOBALS['NETTSMED_HELP_STACK_LABELS'] = [
+    'elementor' => 'Elementor',
+    'gutenberg' => 'Gutenberg',
+    'woocommerce' => 'WooCommerce',
+    'wordpress' => 'WordPress',
+    'generell' => 'Generelt'
+	];
+	$GLOBALS['NETTSMED_OPEN_NEXT_PATHS'] = [ '', '/drift', '/faktura', '/support' ];
+	$GLOBALS['NETTSMED_HELP_ARTICLE_SLUGS'] = [
+    'wordpress/introduksjon',
+    'wordpress/side-vs-innlegg',
+    'wordpress/publisering',
+    'wordpress/endre-lenker',
+    'wordpress/lokal-nettleser',
+    'wordpress/logge-inn',
+    'wordpress/glemt-passord',
+    'wordpress/nye-brukere',
+    'wordpress/gutenberg',
+    'elementor/introduksjon',
+    'sikkerhet/tofaktor'
+	];
+}

--- a/inc/minside-sso.php
+++ b/inc/minside-sso.php
@@ -17,12 +17,19 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+// Cross-language SSO contract (JWT iss/aud/TTL) — single source of truth shared
+// with minside's verifier via @nettsmed/contracts. Vendored + auto-generated:
+// regenerate with `pnpm gen:php` in the minside-nettsmed monorepo, then re-copy
+// contracts.generated.php here and re-commit. See inc/contracts.generated.php.
+require_once __DIR__ . '/contracts.generated.php';
+
 // ── Konstanter ─────────────────────────────────────────────────────────────
 
 const MINSIDE_URL_DEFAULT = 'https://minside.nettsmed.no';
-const SSO_ISSUER          = 'nettsmed-support-plugin';
-const SSO_AUD             = 'minside.nettsmed.no';
-const SSO_TTL_SECONDS     = 90;   // exp = iat + 90 s (ned fra 600)
+// JWT contract values are sourced from contracts.generated.php (do not hardcode).
+const SSO_ISSUER          = \NETTSMED_SSO_ISS;   // 'nettsmed-support-plugin'
+const SSO_AUD             = \NETTSMED_SSO_AUD;   // 'minside.nettsmed.no'
+const SSO_TTL_SECONDS     = \NETTSMED_SSO_TTL;   // exp = iat + 90 s
 const OPTION_SITE_KEY     = 'minside_sso_site_key';
 const REQUIRED_CAPABILITY = 'manage_options';
 const ADMIN_POST_ACTION   = 'minside_sso_launch';

--- a/site-customization-by-fjellestad-design.php
+++ b/site-customization-by-fjellestad-design.php
@@ -3,7 +3,7 @@
 * Plugin Name: Site Customization by Nettsmed
 * Plugin URI: https://nettsmed.no
 * Description: Site customization plugin for Nettsmed customers.
- * Version: 1.8.0
+ * Version: 1.8.1
 * Author: Sindre Fjellestad
 * Author URI: https://github.com/Sinfjell
 */


### PR DESCRIPTION
## Hva

SSO-minteren (`inc/minside-sso.php`) henter nå JWT-kontraktverdiene (`iss`, `aud`, TTL) fra en **vendret, auto-generert `inc/contracts.generated.php`** i stedet for hardkodede konstanter. Dette er samme kontrakt minside sin verifier konsumerer via `@nettsmed/contracts` i `nettsmed-kundestotte`-monorepoet → **én sannhetskilde**, ingen cross-repo drift.

## Hvorfor

Før dette var `iss`/`aud`/`ttl` hardkodet to steder (her + i minside sin TS). Nå avledes begge sider fra `packages/contracts`.

## Sikkerhet / korrekthet

- Emitterte token-verdier (`iss=nettsmed-support-plugin`, `aud=minside.nettsmed.no`, `ttl=90`) er **byte-for-byte identiske med 1.8.0**.
- Verifisert med en ekvivalens-harness som inkluderer den ekte fila og asserter de resolverte konstantene (`SSO_ISSUER`/`SSO_AUD`/`SSO_TTL_SECONDS`) → alle OK, `NETTSMED_CONTRACTS_LOADED=true`.
- `php -l` rent på alle tre PHP-filer.
- Ingen runtime-atferdsendring. `require_once` står før const-deklarasjonene; kontraktfila har egen `defined()`-guard.

## Flåte-release

- Version bumpet 1.8.0 → **1.8.1** (PATCH/refactor), CHANGELOG oppdatert.
- Sindre styrer selve Kernl-release + per-site oppdatering.
- Ved fremtidige kontraktendringer: `pnpm gen:php` i monorepoet → kopiér `contracts.generated.php` hit → re-commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)